### PR TITLE
Add basic desktop automation tool

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -81,6 +81,37 @@ def run_tests(_: str) -> str:
     return run_shell("pytest -q")
 
 
+def control_desktop(action: str) -> str:
+    """Capture the desktop and perform a simple automation.
+
+    The function saves a screenshot to ``desktop.png`` and performs a couple of
+    very small automations using ``pyautogui``. Currently it understands the
+    phrases "click start" and "open settings" which, when combined, will open
+    the system settings menu on most operating systems.
+
+    Parameters
+    ----------
+    action: str
+        Natural language description of the desired automation.
+    """
+
+    import pyautogui  # type: ignore
+
+    screenshot = pyautogui.screenshot()
+    path = "desktop.png"
+    screenshot.save(path)
+
+    lowered = action.lower()
+    if "click start" in lowered:
+        width, height = pyautogui.size()
+        pyautogui.moveTo(10, height - 10)
+        pyautogui.click()
+    if "open settings" in lowered:
+        pyautogui.write("settings")
+        pyautogui.press("enter")
+    return f"Screenshot saved to {path}"
+
+
 class OpenAILLM:
     """Small wrapper around the OpenAI chat completions API."""
 
@@ -188,6 +219,11 @@ def build_default_agent() -> Agent:
         Tool("search", "Search files for a pattern", search_files),
         Tool("git", "Run git commands", run_git),
         Tool("test", "Run tests with pytest", run_tests),
+        Tool(
+            "desktop",
+            "Take a screenshot and perform simple desktop automations",
+            control_desktop,
+        ),
     ]
     llm = OpenAILLM(model=os.getenv("OPENAI_MODEL", "gpt-4o-mini"))
     system_prompt = os.getenv("AGENT_SYSTEM_PROMPT", "You are a helpful coding agent.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.0
 pytest>=7.0
+pyautogui>=0.9

--- a/test_control_desktop.py
+++ b/test_control_desktop.py
@@ -1,0 +1,43 @@
+import sys
+import types
+
+from agent import control_desktop
+
+def test_control_desktop_automation(monkeypatch):
+    calls = []
+
+    class DummyImage:
+        def save(self, path):
+            calls.append(("save", path))
+
+    def screenshot():
+        return DummyImage()
+
+    def size():
+        return (100, 100)
+
+    def moveTo(x, y):
+        calls.append(("moveTo", x, y))
+
+    def click():
+        calls.append(("click",))
+
+    def write(text):
+        calls.append(("write", text))
+
+    def press(key):
+        calls.append(("press", key))
+
+    dummy_module = types.SimpleNamespace(
+        screenshot=screenshot,
+        size=size,
+        moveTo=moveTo,
+        click=click,
+        write=write,
+        press=press,
+    )
+    monkeypatch.setitem(sys.modules, "pyautogui", dummy_module)
+    result = control_desktop("click start and open settings")
+    assert "Screenshot saved to" in result
+    assert ("moveTo", 10, 90) in calls
+    assert ("press", "enter") in calls


### PR DESCRIPTION
## Summary
- add `control_desktop` function using pyautogui for simple GUI automation
- expose desktop automation as an agent tool
- include pyautogui dependency and accompanying unit test

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aca7633fe48322af4ba1f84a4aa41f